### PR TITLE
Add org.bitbucket.b_c:jose4j:0.9.3 to the benchmark

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ ext {
     junitJupiterVersion = '5.10.0'
     jaxbVersion = '2.3.1'
     bouncyCastleVersion = '1.76'
+    jose4jVersion = '0.9.3'
 }
 
 def buildProjects() {

--- a/frameworks/jose4j-bench/README.md
+++ b/frameworks/jose4j-bench/README.md
@@ -1,0 +1,4 @@
+# jose4j-bench
+Benchmark configuration for [jose4j].
+
+[java-jwt]:			https://bitbucket.org/b_c/jose4j

--- a/frameworks/jose4j-bench/build.gradle
+++ b/frameworks/jose4j-bench/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    api("org.bitbucket.b_c:jose4j:${jose4jVersion}")
+}
+

--- a/frameworks/jose4j-bench/src/main/java/org/jose4j/jwt/Jose4JEncoder.java
+++ b/frameworks/jose4j-bench/src/main/java/org/jose4j/jwt/Jose4JEncoder.java
@@ -1,0 +1,41 @@
+package org.jose4j.jwt;
+
+import java.security.KeyPair;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Date;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jws.AlgorithmIdentifiers;
+
+public class Jose4JEncoder {
+
+    private final KeyPair keyPair;
+
+    public Jose4JEncoder(KeyPair keyPair) {
+        this.keyPair = keyPair;
+    }
+
+    public String generateToken(Map<String, Object> keys, String issuer, String audience) throws Exception {
+        JwtClaims claims = new JwtClaims();
+        claims.setIssuer(issuer);
+        claims.setAudience(audience);
+        claims.setIssuedAtToNow();
+        claims.setExpirationTimeMinutesInTheFuture(24 * 60 * 60);
+
+        for (Entry<String, Object> entry : keys.entrySet()) {
+            claims.setClaim(entry.getKey(), entry.getValue());
+        }
+
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setPayload(claims.toJson());
+        jws.setKey((RSAPrivateKey) keyPair.getPrivate());
+        jws.setKeyIdHeaderValue("12345678");
+        jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.RSA_USING_SHA256);
+
+        return jws.getCompactSerialization();
+    }
+
+}

--- a/frameworks/jose4j-bench/src/main/java/org/jose4j/jwt/Jose4JTokenVerifier.java
+++ b/frameworks/jose4j-bench/src/main/java/org/jose4j/jwt/Jose4JTokenVerifier.java
@@ -1,0 +1,37 @@
+package org.jose4j.jwt;
+
+import java.security.KeyPair;
+
+import org.jose4j.jwk.JsonWebKey;
+import org.jose4j.jwt.consumer.JwtConsumer;
+import org.jose4j.jwt.consumer.JwtConsumerBuilder;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.consumer.JwtContext;
+
+public class Jose4JTokenVerifier {
+
+	public static Jose4JTokenVerifier newInstance(KeyPair keyPair, String issuer, String audience) {
+		JwtConsumer consumer = new JwtConsumerBuilder()
+				.setVerificationKey(keyPair.getPublic())
+				.setRequireExpirationTime()
+				.setExpectedIssuer(issuer)
+				.setExpectedAudience(audience)
+				.build();
+
+		return new Jose4JTokenVerifier(consumer);
+	}
+
+	private final JwtConsumer consumer;
+
+	public Jose4JTokenVerifier(JwtConsumer consumer) {
+		this.consumer = consumer;
+	}
+
+	public JwtClaims verifyJsonWebToken(String token) throws Exception {
+		return consumer.processToClaims(token);
+	}
+
+	public JwtContext parseToken(String token) throws Exception {
+		return consumer.process(token);
+	}
+}

--- a/jmh-benchmark/build.gradle
+++ b/jmh-benchmark/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     jmh project(":frameworks:okta-jwt-verifier-bench")
     jmh project(":frameworks:fusionauth-jwt-bench")
     jmh project(":frameworks:nimbus-bench")
+    jmh project(":frameworks:jose4j-bench")
     jmh project(":frameworks:baseline-bench")
 
     jmh project(":jmh-utils")

--- a/jmh-benchmark/src/jmh/java/com/github/skjolber/jwt/BenchmarkState.java
+++ b/jmh-benchmark/src/jmh/java/com/github/skjolber/jwt/BenchmarkState.java
@@ -1,5 +1,6 @@
 package com.github.skjolber.jwt;
 
+import org.jose4j.jwt.Jose4JTokenVerifier;
 import com.auth0.jwt.Auth0TokenVerifier;
 import com.github.skjolber.bench.baseline.bc.BaseBouncyCastleJwtVerifier;
 import com.github.skjolber.bench.baseline.jdk.BaseJdkJwtVerifier;
@@ -29,6 +30,7 @@ public class BenchmarkState {
 
 	private BaseBouncyCastleJwtVerifier baseBouncyCastleJwtVerifier;
 	private BaseJdkJwtVerifier baseJdkJwtVerifier;
+	private Jose4JTokenVerifier jose4JTokenVerifier;
 
 	@Setup(Level.Trial)
 	public void init() throws Exception {
@@ -53,6 +55,7 @@ public class BenchmarkState {
 
 		baseBouncyCastleJwtVerifier = BaseBouncyCastleJwtVerifier.newInstance(generator.getKeyPair(), issuer, audience, token);
 		baseJdkJwtVerifier = BaseJdkJwtVerifier.newInstance(generator.getKeyPair(), issuer, audience, token);
+		jose4JTokenVerifier = Jose4JTokenVerifier.newInstance(generator.getKeyPair(), issuer, audience);
 	}
 	
 	public Auth0TokenVerifier getAuth0TokenVerifier() {
@@ -85,5 +88,9 @@ public class BenchmarkState {
 
 	public BaseJdkJwtVerifier getBaseJdkJwtVerifier() {
 		return baseJdkJwtVerifier;
+	}
+
+	public Jose4JTokenVerifier getJose4JTokenVerifier() {
+		return jose4JTokenVerifier;
 	}
 }

--- a/jmh-benchmark/src/jmh/java/com/github/skjolber/jwt/JwtClaimBenchmark.java
+++ b/jmh-benchmark/src/jmh/java/com/github/skjolber/jwt/JwtClaimBenchmark.java
@@ -31,4 +31,9 @@ public class JwtClaimBenchmark {
         return state.getFusionAuthJsonWebTokenVerifier().verifyJsonWebToken(state.getToken()).getObject("test");
     }
 
+    @Benchmark
+    public Object jose4j_claim(BenchmarkState state) throws Exception {
+        return state.getJose4JTokenVerifier().verifyJsonWebToken(state.getToken()).getStringClaimValue("test");
+    }
+
 }

--- a/jmh-benchmark/src/jmh/java/com/github/skjolber/jwt/JwtParseBenchmark.java
+++ b/jmh-benchmark/src/jmh/java/com/github/skjolber/jwt/JwtParseBenchmark.java
@@ -3,6 +3,7 @@ package com.github.skjolber.jwt;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import io.fusionauth.jwt.domain.JWT;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.jose4j.jwt.consumer.JwtContext;
 
 import java.text.ParseException;
 
@@ -21,6 +22,11 @@ public class JwtParseBenchmark {
     @Benchmark
     public DecodedJWT auth0_parse(BenchmarkState state) {
         return state.getAuth0TokenVerifier().parseToken(state.getToken());
+    }
+
+    @Benchmark
+    public JwtContext jose4j_parse(BenchmarkState state) throws Exception {
+        return state.getJose4JTokenVerifier().parseToken(state.getToken());
     }
 
 }

--- a/jmh-benchmark/src/jmh/java/com/github/skjolber/jwt/JwtVerifyBenchmark.java
+++ b/jmh-benchmark/src/jmh/java/com/github/skjolber/jwt/JwtVerifyBenchmark.java
@@ -37,6 +37,11 @@ public class JwtVerifyBenchmark {
         return state.getAuth0TokenVerifier().verifyJsonWebToken(state.getToken());
     }
 
+    @Benchmark
+    public Object jose4_verify(BenchmarkState state) throws Exception {
+        return state.getJose4JTokenVerifier().verifyJsonWebToken(state.getToken());
+    }
+
     /*
     @Benchmark
     public Object okta_verify(BenchmarkState state) throws Exception {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-include 'jmh-utils', 'frameworks:java-jwt-bench', 'frameworks:jjwt-bench', 'frameworks:okta-jwt-verifier-bench', 'frameworks:fusionauth-jwt-bench', "frameworks:nimbus-bench", "frameworks:baseline-bench"
+include 'jmh-utils', 'frameworks:java-jwt-bench', 'frameworks:jjwt-bench', 'frameworks:okta-jwt-verifier-bench', 'frameworks:fusionauth-jwt-bench', "frameworks:nimbus-bench", "frameworks:baseline-bench", "frameworks:jose4j-bench"
 include 'jmh-benchmark'


### PR DESCRIPTION
Benchmarks on my computer:
```
Benchmark                              Mode  Cnt        Score       Error  Units
JwtClaimBenchmark.auth0_claim         thrpt    5    26873.688 ±   366.849  ops/s
JwtClaimBenchmark.fusionauth_claim    thrpt    5    27517.920 ±   336.046  ops/s
JwtClaimBenchmark.jjwt_claim          thrpt    5    22316.534 ±    96.435  ops/s
JwtClaimBenchmark.jose4j_claim        thrpt    5    20711.429 ±   206.952  ops/s
JwtClaimBenchmark.nimbus_claim        thrpt    5    13336.509 ±    28.226  ops/s
JwtParseBenchmark.auth0_parse         thrpt    5   714058.658 ± 10809.961  ops/s
JwtParseBenchmark.fusionauth_parse    thrpt    5  1258417.436 ± 33001.908  ops/s
JwtParseBenchmark.jose4j_parse        thrpt    5    20351.163 ±   217.660  ops/s
JwtParseBenchmark.nimbus_parse        thrpt    5   433384.663 ±  2608.515  ops/s
JwtVerifyBenchmark.auth0_verify       thrpt    5    24268.564 ±   555.779  ops/s
JwtVerifyBenchmark.base_verify_bc     thrpt    5    28959.195 ±   352.117  ops/s
JwtVerifyBenchmark.base_verify_jdk    thrpt    5    28355.249 ±   142.353  ops/s
JwtVerifyBenchmark.fusionauth_verify  thrpt    5    25218.687 ±  3663.365  ops/s
JwtVerifyBenchmark.jjwt_verify        thrpt    5    21838.852 ±   588.251  ops/s
JwtVerifyBenchmark.jose4_verify       thrpt    5    20358.460 ±   303.718  ops/s
JwtVerifyBenchmark.nimbus_verify      thrpt    5    13302.532 ±   234.637  ops/s
```